### PR TITLE
fix: typo in SearchAction

### DIFF
--- a/lib/schema_dot_org/search_action.rb
+++ b/lib/schema_dot_org/search_action.rb
@@ -13,7 +13,7 @@ module SchemaDotOrg
     def _to_json_struct
       {
         'target' => self.target,
-        'query-input' => self.query_input
+        'query_input' => self.query_input
       }
     end
   end


### PR DESCRIPTION
After cloning the repo and running the tests, without having changed any
code, two tests were failing. This fixes those.