### PR TITLE
better modeling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schema_dot_org (2.5.1)
+    schema_dot_org (2.5.3)
       validated_object (~> 2.3.4)
 
 GEM

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -23,7 +23,7 @@ module SchemaDotOrg
     validated_attr :founding_date,     type: Date,                                allow_nil: true
     validated_attr :founding_location, type: Place,                               allow_nil: true
     validated_attr :legal_name,        type: String,                              allow_nil: true
-    validated_attr :same_as,           type: Array,                               allow_nil: true
+    validated_attr :same_as,           type: union(String, [String]),             allow_nil: true
     validated_attr :slogan,            type: String,                              allow_nil: true
     validated_attr :telephone,         type: String,                              allow_nil: true
 

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -13,17 +13,17 @@ module SchemaDotOrg
   #
   class Organization < SchemaType
     validated_attr :address,           type: PostalAddress, allow_nil: true
-    validated_attr :contact_points,    type: Array, allow_nil: true
-    validated_attr :email,             type: String, allow_nil: true
-    validated_attr :founder,           type: Person, allow_nil: true
-    validated_attr :founding_date,     type: Date, allow_nil: true
-    validated_attr :founding_location, type: Place, allow_nil: true
-    validated_attr :legal_name,        type: String, allow_nil: true
+    validated_attr :contact_points,    type: Array,         allow_nil: true
+    validated_attr :email,             type: String,        allow_nil: true
+    validated_attr :founder,           type: Person,        allow_nil: true
+    validated_attr :founding_date,     type: Date,          allow_nil: true
+    validated_attr :founding_location, type: Place,         allow_nil: true
+    validated_attr :legal_name,        type: String,        allow_nil: true
     validated_attr :logo,              type: String
     validated_attr :name,              type: String
-    validated_attr :same_as,           type: Array, allow_nil: true
-    validated_attr :slogan,            type: String, allow_nil: true
-    validated_attr :telephone,         type: String, allow_nil: true
+    validated_attr :same_as,           type: Array,         allow_nil: true
+    validated_attr :slogan,            type: String,        allow_nil: true
+    validated_attr :telephone,         type: String,        allow_nil: true
 
     # Google allows `url` to be a string:
     # https://developers.google.com/search/docs/appearance/structured-data/logo

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -12,20 +12,23 @@ module SchemaDotOrg
   # See https://schema.org/Organization
   #
   class Organization < SchemaType
-    validated_attr :address,           type: PostalAddress, allow_nil: true
-    validated_attr :contact_points,    type: Array,         allow_nil: true
-    validated_attr :email,             type: String,        allow_nil: true
-    validated_attr :founder,           type: Person,        allow_nil: true
-    validated_attr :founding_date,     type: Date,          allow_nil: true
-    validated_attr :founding_location, type: Place,         allow_nil: true
-    validated_attr :legal_name,        type: String,        allow_nil: true
+    validated_attr :address,           type: PostalAddress,                       allow_nil: true
+    validated_attr :contact_points,    type: union(ContactPoint, [ContactPoint]), allow_nil: true
+    validated_attr :email,             type: String,                              allow_nil: true
+    validated_attr :founder,           type: Person,                              allow_nil: true
+    validated_attr :founding_date,     type: Date,                                allow_nil: true
+    validated_attr :founding_location, type: Place,                               allow_nil: true
+    validated_attr :legal_name,        type: String,                              allow_nil: true
+    validated_attr :same_as,           type: Array,                               allow_nil: true
+    validated_attr :slogan,            type: String,                              allow_nil: true
+    validated_attr :telephone,         type: String,                              allow_nil: true
+
+    #
+    # Attributes that are required by Google
+    #
     validated_attr :logo,              type: String
     validated_attr :name,              type: String
-    validated_attr :same_as,           type: Array,         allow_nil: true
-    validated_attr :slogan,            type: String,        allow_nil: true
-    validated_attr :telephone,         type: String,        allow_nil: true
-
-    # Google allows `url` to be a string:
+    # Google allows `url` to be a string, although schema.org does not:
     # https://developers.google.com/search/docs/appearance/structured-data/logo
     validated_attr :url,               type: String
   end

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -11,10 +11,6 @@ module SchemaDotOrg
   ##
   # See https://schema.org/Organization
   #
-  # TODO: Think about the naming of `contact_points`. Would `contact_point` be
-  # better? Organization changed, and now the property is singular, but it can
-  # still accept multiple values.
-  #
   class Organization < SchemaType
     validated_attr :address,           type: PostalAddress,                       allow_nil: true
     validated_attr :contact_points,    type: union(ContactPoint, [ContactPoint]), allow_nil: true

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -32,8 +32,6 @@ module SchemaDotOrg
     ########################################
     validated_attr :logo,              type: String
     validated_attr :name,              type: String
-    # Google allows `url` to be a string, although schema.org does not:
-    # https://developers.google.com/search/docs/appearance/structured-data/logo
     validated_attr :url,               type: String
   end
 end

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -12,12 +12,12 @@ module SchemaDotOrg
   # See https://schema.org/Organization
   #
   class Organization < SchemaType
-    validated_attr :address,           type: SchemaDotOrg::PostalAddress, allow_nil: true
+    validated_attr :address,           type: PostalAddress, allow_nil: true
     validated_attr :contact_points,    type: Array, allow_nil: true
     validated_attr :email,             type: String, allow_nil: true
-    validated_attr :founder,           type: SchemaDotOrg::Person, allow_nil: true
+    validated_attr :founder,           type: Person, allow_nil: true
     validated_attr :founding_date,     type: Date, allow_nil: true
-    validated_attr :founding_location, type: SchemaDotOrg::Place, allow_nil: true
+    validated_attr :founding_location, type: Place, allow_nil: true
     validated_attr :legal_name,        type: String, allow_nil: true
     validated_attr :logo,              type: String
     validated_attr :name,              type: String

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -27,9 +27,9 @@ module SchemaDotOrg
     validated_attr :slogan,            type: String,                              allow_nil: true
     validated_attr :telephone,         type: String,                              allow_nil: true
 
-    #
+    ########################################
     # Attributes that are required by Google
-    #
+    ########################################
     validated_attr :logo,              type: String
     validated_attr :name,              type: String
     # Google allows `url` to be a string, although schema.org does not:

--- a/lib/schema_dot_org/organization.rb
+++ b/lib/schema_dot_org/organization.rb
@@ -11,6 +11,10 @@ module SchemaDotOrg
   ##
   # See https://schema.org/Organization
   #
+  # TODO: Think about the naming of `contact_points`. Would `contact_point` be
+  # better? Organization changed, and now the property is singular, but it can
+  # still accept multiple values.
+  #
   class Organization < SchemaType
     validated_attr :address,           type: PostalAddress,                       allow_nil: true
     validated_attr :contact_points,    type: union(ContactPoint, [ContactPoint]), allow_nil: true

--- a/schema_dot_org.gemspec
+++ b/schema_dot_org.gemspec
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
   spec.name          = 'schema_dot_org'
-  spec.version       = '2.5.2'
+  spec.version       = '2.5.3'
   spec.authors       = ['Robert Shecter']
   spec.email         = ['robert@public.law']
 

--- a/schema_dot_org.gemspec
+++ b/schema_dot_org.gemspec
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
   spec.name          = 'schema_dot_org'
-  spec.version       = '2.5.3'
+  spec.version       = '2.5.2'
   spec.authors       = ['Robert Shecter']
   spec.email         = ['robert@public.law']
 

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -5,6 +5,15 @@ require 'schema_dot_org'
 
 
 RSpec.describe SchemaDotOrg::Organization do
+  let(:main_office) do
+    SchemaDotOrg::ContactPoint.new(
+      contact_type: 'customer service',
+      telephone: '+1-800-555-1212',
+      contact_option: 'TollFree',
+      available_language: %w[English Spanish]
+    )
+  end
+
   describe '#new' do
     it 'will not create with an unknown attribute' do
       expect do
@@ -44,14 +53,8 @@ RSpec.describe SchemaDotOrg::Organization do
       end.not_to raise_error(NoMethodError)
     end
 
-    it 'is valid with a single ContactPoint' do
-      main_office = SchemaDotOrg::ContactPoint.new(
-        contact_type: 'customer service',
-        telephone: '+1-800-555-1212',
-        contact_option: 'TollFree',
-        available_language: %w[English Spanish]
-      )
 
+    it 'is valid with a single ContactPoint' do
       expect do
         SchemaDotOrg::Organization.new(
           name: 'Public.Law',
@@ -72,13 +75,6 @@ RSpec.describe SchemaDotOrg::Organization do
 
 
     it 'is valid with two ContactPoints' do
-      main_office = SchemaDotOrg::ContactPoint.new(
-        contact_type: 'customer service',
-        telephone: '+1-800-555-1212',
-        contact_option: 'TollFree',
-        available_language: %w[English Spanish]
-      )
-
       hr_office = SchemaDotOrg::ContactPoint.new(
         contact_type: 'human resources',
         telephone: '+1-800-555-1213',

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -35,7 +35,25 @@ RSpec.describe SchemaDotOrg::Organization do
     end
 
 
-    it 'is invalid without a name' do
+    it 'is invalid without a logo' do
+      expect do
+        SchemaDotOrg::Organization.new(
+          name: 'Public.Law',
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          same_as: [
+            'https://twitter.com/law_is_code',
+            'https://www.facebook.com/PublicDotLaw'
+          ]
+        )
+      end.to raise_error(ArgumentError, /Logo/)
+    end
+
+
+    it 'is invalid without a URL' do
       expect do
         SchemaDotOrg::Organization.new(
           name: 'Public.Law',

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe SchemaDotOrg::Organization do
     it 'is invalid without a name' do
       expect do
         SchemaDotOrg::Organization.new(
+          name: 'Public.Law',
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          same_as: [
+            'https://twitter.com/law_is_code',
+            'https://www.facebook.com/PublicDotLaw'
+          ]
+        )
+      end.to raise_error(ArgumentError, /Logo/)
+    end
+
+
+    it 'is invalid without a logo' do
+      expect do
+        SchemaDotOrg::Organization.new(
           founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
           founding_date: Date.new(2009, 3, 6),
           founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe SchemaDotOrg::Organization do
     end
 
 
+    it 'is invalid without a name' do
+      expect do
+        SchemaDotOrg::Organization.new(
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          logo: 'https://www.public.law/favicon-196x196.png',
+          same_as: [
+            'https://twitter.com/law_is_code',
+            'https://www.facebook.com/PublicDotLaw'
+          ]
+        )
+      end.to raise_error(ArgumentError, /Name/)
+    end
+
+
     it 'is valid without an address' do
       expect do
         SchemaDotOrg::Organization.new(

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SchemaDotOrg::Organization do
             'https://www.facebook.com/PublicDotLaw'
           ]
         )
-      end.to raise_error
+      end.to raise_error(NoMethodError, /snack_time/)
     end
 
 

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SchemaDotOrg::Organization do
             'https://www.facebook.com/PublicDotLaw'
           ]
         )
-      end.to raise_error(NoMethodError)
+      end.to raise_error
     end
 
 
@@ -50,7 +50,42 @@ RSpec.describe SchemaDotOrg::Organization do
             'https://www.facebook.com/PublicDotLaw'
           ]
         )
-      end.not_to raise_error(NoMethodError)
+      end.not_to raise_error
+    end
+
+
+    it 'is valid with multiple same_as URLS' do
+      expect do
+        SchemaDotOrg::Organization.new(
+          name: 'Public.Law',
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          logo: 'https://www.public.law/favicon-196x196.png',
+          same_as: [
+            'https://twitter.com/law_is_code',
+            'https://www.facebook.com/PublicDotLaw'
+          ]
+        )
+      end.not_to raise_error
+    end
+
+
+    it 'is valid with a single same_as URL' do
+      expect do
+        SchemaDotOrg::Organization.new(
+          name: 'Public.Law',
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          logo: 'https://www.public.law/favicon-196x196.png',
+          same_as: 'https://twitter.com/law_is_code'
+        )
+      end.not_to raise_error
     end
 
 

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -44,6 +44,66 @@ RSpec.describe SchemaDotOrg::Organization do
       end.not_to raise_error(NoMethodError)
     end
 
+    it 'is valid with a single ContactPoint' do
+      main_office = SchemaDotOrg::ContactPoint.new(
+        contact_type: 'customer service',
+        telephone: '+1-800-555-1212',
+        contact_option: 'TollFree',
+        available_language: %w[English Spanish]
+      )
+
+      expect do
+        SchemaDotOrg::Organization.new(
+          name: 'Public.Law',
+          contact_points: main_office,
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          logo: 'https://www.public.law/favicon-196x196.png',
+          same_as: [
+            'https://twitter.com/law_is_code',
+            'https://www.facebook.com/PublicDotLaw'
+          ]
+        )
+      end.not_to raise_error
+    end
+
+
+    it 'is valid with two ContactPoints' do
+      main_office = SchemaDotOrg::ContactPoint.new(
+        contact_type: 'customer service',
+        telephone: '+1-800-555-1212',
+        contact_option: 'TollFree',
+        available_language: %w[English Spanish]
+      )
+
+      hr_office = SchemaDotOrg::ContactPoint.new(
+        contact_type: 'human resources',
+        telephone: '+1-800-555-1213',
+        contact_option: 'TollFree',
+        available_language: ['English']
+      )
+
+      expect do
+        SchemaDotOrg::Organization.new(
+          name: 'Public.Law',
+          contact_points: [main_office, hr_office],
+          founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
+          founding_date: Date.new(2009, 3, 6),
+          founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
+          email: 'say_hi@public.law',
+          url: 'https://www.public.law',
+          logo: 'https://www.public.law/favicon-196x196.png',
+          same_as: [
+            'https://twitter.com/law_is_code',
+            'https://www.facebook.com/PublicDotLaw'
+          ]
+        )
+      end.not_to raise_error
+    end
+
 
     it 'creates correct json correctly' do
       address = SchemaDotOrg::PostalAddress.new(

--- a/spec/schema_dot_org/organization_spec.rb
+++ b/spec/schema_dot_org/organization_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SchemaDotOrg::Organization do
     it 'will not create with an unknown attribute' do
       expect do
         SchemaDotOrg::Organization.new(
-          snack_time: 'today',
+          snack_time: 'today', # !!!
           name: 'Public.Law',
           founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),
           founding_date: Date.new(2009, 3, 6),
@@ -61,17 +61,17 @@ RSpec.describe SchemaDotOrg::Organization do
           founding_date: Date.new(2009, 3, 6),
           founding_location: SchemaDotOrg::Place.new(address: 'Portland, OR'),
           email: 'say_hi@public.law',
-          url: 'https://www.public.law',
+          logo: 'https://www.public.law/favicon-196x196.png',
           same_as: [
             'https://twitter.com/law_is_code',
             'https://www.facebook.com/PublicDotLaw'
           ]
         )
-      end.to raise_error(ArgumentError, /Logo/)
+      end.to raise_error(ArgumentError, /Url/)
     end
 
 
-    it 'is invalid without a logo' do
+    it 'is invalid without a name' do
       expect do
         SchemaDotOrg::Organization.new(
           founder: SchemaDotOrg::Person.new(name: 'Robb Shecter'),


### PR DESCRIPTION
Improved the Organization object to use the new `union()` and Array options. It now validates that `contact_points` and `same_as` can either be a single object or an array of objects.

```ruby
  ##
  # See https://schema.org/Organization
  #
  class Organization < SchemaType
    validated_attr :address,           type: PostalAddress,                       allow_nil: true
    validated_attr :contact_points,    type: union(ContactPoint, [ContactPoint]), allow_nil: true
    validated_attr :email,             type: String,                              allow_nil: true
    validated_attr :founder,           type: Person,                              allow_nil: true
    validated_attr :founding_date,     type: Date,                                allow_nil: true
    validated_attr :founding_location, type: Place,                               allow_nil: true
    validated_attr :legal_name,        type: String,                              allow_nil: true
    validated_attr :same_as,           type: union(String, [String]),             allow_nil: true
    validated_attr :slogan,            type: String,                              allow_nil: true
    validated_attr :telephone,         type: String,                              allow_nil: true

    ########################################
    # Attributes that are required by Google
    ########################################
    validated_attr :logo,              type: String
    validated_attr :name,              type: String
    validated_attr :url,               type: String
  end

```

Note that in schema.org, **any** property can be an array of multiple items. So far, though, in this gem, we're enabling that one at a time when needed.