### PR TITLE
chore: remove deprecated Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.4.0
-  - 2.5.1
-  - 2.6.6
-before_install: gem install bundler -v 1.16.1


### PR DESCRIPTION
Since Github Actions is used now.